### PR TITLE
fix: 修复掘金下的文章复制markdown, 代码块没有换行，应用了行内代码片段样式

### DIFF
--- a/src/turndown.js
+++ b/src/turndown.js
@@ -27,19 +27,38 @@ turndownService.addRule("autoLanguage", {
     return Boolean(
       options.codeBlockStyle === "fenced" &&
         node.nodeName === "PRE" &&
-        node.firstChild &&
-        node.firstChild.nodeName === "CODE"
+        node.childNodes &&
+        Array.from(node.childNodes).some(node => node.nodeName === "CODE")
     );
   },
 
   replacement(content, node, options) {
-    const className = [node.className, node.firstElementChild?.className].join(
+    const beforeNodes = []
+    let codeEle = null
+    node.childNodes.forEach(child => {
+      if (codeEle) return
+      if (child.nodeName === "CODE") {
+        codeEle = child
+      } else {
+        beforeNodes.push(child)
+      }
+    })
+    // 删除code元素之前的节点
+    beforeNodes.forEach(node => node.remove?.())
+
+    if (!codeEle) {
+      codeEle = node.firstElementChild
+    }
+
+    const className = [node.className, codeEle.className].join(
       " "
     );
-    const language = (className.match(/language-(\S+)/) || [
-      null,
-      detectLanguage(className),
-    ])[1];
+    const language = 
+      codeEle.getAttribute('lang') ||
+      (className.match(/language-(\S+)/) || [
+        null,
+        detectLanguage(className),
+      ])[1];
     const code = node.textContent || "";
     const fence = options.fence;
 


### PR DESCRIPTION
![image](https://github.com/maqi1520/tampermonkey-copy-helper/assets/7259892/9549821a-d938-4daf-9990-014f76476efd)

打开-掘金文章，执行 复制markdown, 得到的代码如图，修复为正常格式，如下图

![image](https://github.com/maqi1520/tampermonkey-copy-helper/assets/7259892/de9c3c47-8a2c-4787-a279-d04531685a4f)
